### PR TITLE
feat: exposes ssh port for gitlab

### DIFF
--- a/bundles/uds-core-swf/uds-bundle.yaml
+++ b/bundles/uds-core-swf/uds-bundle.yaml
@@ -47,6 +47,26 @@ packages:
               description: "The TLS key for the admin gateway (must be base64 encoded)"
               path: tls.key
       istio-tenant-gateway:
+        gateway:
+          values:
+            - path: "service.ports"
+              value:
+                - name: status-port
+                  port: 15021
+                  protocol: TCP
+                  targetPort: 15021
+                - name: http2
+                  port: 80
+                  protocol: TCP
+                  targetPort: 80
+                - name: https
+                  port: 443
+                  protocol: TCP
+                  targetPort: 443
+                - name: tcp-ssh
+                  port: 22
+                  protocol: TCP
+                  targetPort: 2022
         uds-istio-config:
           variables:
             - name: TENANT_TLS_CERT

--- a/bundles/uds-core-swf/uds-bundle.yaml
+++ b/bundles/uds-core-swf/uds-bundle.yaml
@@ -55,6 +55,7 @@ packages:
             - name: TENANT_TLS_KEY
               description: "The TLS key for the tenant gateway (must be base64 encoded)"
               path: tls.key
+            
 
   # legacy requirements of DUBBD like flux (TODO -- remove someday)
   - name: dubbd-legacy-reqs

--- a/packages/dubbd-legacy-reqs/manifests/gitlab-ssh-gateway.yaml
+++ b/packages/dubbd-legacy-reqs/manifests/gitlab-ssh-gateway.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: gitlab-ssh-gateway
+  namespace: istio-tenant-gateway
+spec:
+  selector:
+    app: tenant-ingressgateway
+  servers:
+    - hosts:
+      - gitlab.###ZARF_VAR_DOMAIN###
+      port:
+        name: tcp-ssh
+        number: 2022
+        protocol: TCP

--- a/packages/dubbd-legacy-reqs/manifests/gitlab-ssh-virtualservice.yaml
+++ b/packages/dubbd-legacy-reqs/manifests/gitlab-ssh-virtualservice.yaml
@@ -8,9 +8,9 @@ metadata:
   namespace: gitlab
 spec:
   gateways:
-  - istio-system/tenant
+  - istio-tenant-gateway/gitlab-ssh-gateway
   hosts:
-  - gitlab.mtsi.bigbang.dev
+  - gitlab.###ZARF_VAR_DOMAIN###
   tcp:
   - match:
     - port: 2022

--- a/packages/dubbd-legacy-reqs/zarf.yaml
+++ b/packages/dubbd-legacy-reqs/zarf.yaml
@@ -6,6 +6,11 @@ metadata:
   architecture: "amd64"
   version: "0.0.1"
 
+variables:
+  - name: DOMAIN
+    description: "Domain to be used in VS hosts and gateway config"
+    default: "mtsi.bigbang.dev"
+
 components:
   - name: install-flux
     required: true
@@ -28,3 +33,4 @@ components:
         files:
           - manifests/gitlab-ssh-virtualservice.yaml
           - manifests/gitlab-ssh-networkpolicies.yaml
+          - manifests/gitlab-ssh-gateway.yaml


### PR DESCRIPTION
Adds an istio gateway for gitlab SSH as well as an additional port for the existing tenant ingressgateway service. Should match the config we had in place with the DUBBD version of the bundle.