### PR TITLE
Adjust GitLab configuration for 2k user benchmarks

### DIFF
--- a/bundles/uds-core-swf/uds-bundle.yaml
+++ b/bundles/uds-core-swf/uds-bundle.yaml
@@ -130,6 +130,12 @@ packages:
             - name: WEBSERVICE_REPLICAS
               description: "Gitlab Webservice Min Replicas"
               path: "gitlab.webservice.minReplicas"
+            - name: WEBSERVICE_WORKERS
+              description: "Gitlab Webservice Worker Count"
+              path: "gitlab.webservice.workerProcesses"
+            - name: WEBSERVICE_HPA
+              description: "Gitlab Webservice HPA settings"
+              path: "gitlab.webservice.hpa"
             - name: WEBSERVICE_RESOURCES
               description: "Gitlab Webservice Resources"
               path: "gitlab.webservice.resources"
@@ -139,6 +145,9 @@ packages:
             - name: SIDEKIQ_REPLICAS
               description: "Gitlab Sidekiq Min Replicas"
               path: "gitlab.sidekiq.minReplicas"
+            - name: SIDEKIQ_HPA
+              description: "Gitlab Sidekiq HPA settings"
+              path: "gitlab.sidekiq.hpa"
             - name: SIDEKIQ_RESOURCES
               description: "Gitlab Sidekiq Resources"
               path: "gitlab.sidekiq.resources"

--- a/config/dev-cluster/uds-config.yaml
+++ b/config/dev-cluster/uds-config.yaml
@@ -35,14 +35,18 @@ variables:
     GITLAB_BACKUP_EXTRA_ARGS: "--skip artifiacts,registry"
     BUCKET_SUFFIX: "-dev"
     GITLAB_REDIS_ENDPOINT: "redis-master.dev-redis.svc.cluster.local"
-    WEBSERVICE_REPLICAS: 2
+    WEBSERVICE_REPLICAS: 3
+    WEBSERVICE_WORKERS: 4
+    WEBSERVICE_HPA:
+      cpu:
+        targetAverageValue: 1600m
     WEBSERVICE_RESOURCES:
       limits:
         cpu: 8000m
         memory: 8G
       requests:
-        cpu: 8000m
-        memory: 8G
+        cpu: 4000m
+        memory: 5G
     MIGRATIONS_RESOURCES:
       limits:
         cpu: 500m
@@ -53,14 +57,17 @@ variables:
       requests:
         cpu: 10m
         memory: 10M
-    SIDEKIQ_REPLICAS: 1
+    SIDEKIQ_REPLICAS: 3
+    SIDEKIQ_HPA:
+      cpu:
+        targetAverageValue: 700m
     SIDEKIQ_RESOURCES:
       limits:
-        cpu: 4000m
-        memory: 15G
+        cpu: 2000m
+        memory: 4G
       requests:
-        cpu: 4000m
-        memory: 15G
+        cpu: 1000m
+        memory: 2G
     GITALY_RESOURCES:
       limits:
         cpu: 4000m

--- a/config/test-cluster/uds-config.yaml
+++ b/config/test-cluster/uds-config.yaml
@@ -35,14 +35,18 @@ variables:
     GITLAB_BACKUP_EXTRA_ARGS: "--skip artifiacts,registry"
     BUCKET_SUFFIX: "-test"
     GITLAB_REDIS_ENDPOINT: "redis-master.dev-redis.svc.cluster.local"
-    WEBSERVICE_REPLICAS: 2
+    WEBSERVICE_REPLICAS: 3
+    WEBSERVICE_WORKERS: 4
+    WEBSERVICE_HPA:
+      cpu:
+        targetAverageValue: 1600m
     WEBSERVICE_RESOURCES:
       limits:
         cpu: 8000m
         memory: 8G
       requests:
-        cpu: 8000m
-        memory: 8G
+        cpu: 4000m
+        memory: 5G
     MIGRATIONS_RESOURCES:
       limits:
         cpu: 500m
@@ -53,14 +57,17 @@ variables:
       requests:
         cpu: 10m
         memory: 10M
-    SIDEKIQ_REPLICAS: 1
+    SIDEKIQ_REPLICAS: 3
+    SIDEKIQ_HPA:
+      cpu:
+        targetAverageValue: 700m
     SIDEKIQ_RESOURCES:
       limits:
-        cpu: 4000m
-        memory: 15G
+        cpu: 2000m
+        memory: 4G
       requests:
-        cpu: 4000m
-        memory: 15G
+        cpu: 1000m
+        memory: 2G
     GITALY_RESOURCES:
       limits:
         cpu: 4000m
@@ -68,6 +75,8 @@ variables:
       requests:
         cpu: 4000m
         memory: 15G
+    REGISTRY_REPLICAS: 2
+    SHELL_REPLICAS: 2
   sonarqube-database-secret:
     SONARQUBE_DB_PASSWORD: "replace-me-db-passwords"
   sonarqube:


### PR DESCRIPTION
- Increase GitLab webservice worker count to match resources
- Adjust HPA targets for webservice and sidekiq to match gitlab 2k ref helm values
- Adjust resource requests and limits to match gitlab 2k ref helm values
- Adjust min replicas to match or exceed 2k ref helm values to enable benchmark tests to hit their targets