### PR TITLE
chore: fix incorrect helm path for workhorse resources

### DIFF
--- a/bundles/uds-core-swf/uds-bundle.yaml
+++ b/bundles/uds-core-swf/uds-bundle.yaml
@@ -221,7 +221,7 @@ packages:
               path: "gitlab.webservice.resources"
             - name: WORKHORSE_RESOURCES
               description: "Gitlab Workhorse Resources"
-              path: "gitlab.workhorse.resources"
+              path: "gitlab.webservice.workhorse.resources"
             - name: SIDEKIQ_REPLICAS
               description: "Gitlab Sidekiq Min Replicas"
               path: "gitlab.sidekiq.minReplicas"


### PR DESCRIPTION
I think this is downstream impact of a bug i had in the bundle definition for the gitlab package. The helm path for workhorse resources is actually `gitlab.webservice.workhorse.resources`. Once available in zarf, we will configure some of these common paths at the package level so they can be consistent and updated there is there is a change. 