### PR TITLE
docs: added SSO integration note for Jira and Confluence

### DIFF
--- a/docs/sso-integration.md
+++ b/docs/sso-integration.md
@@ -1,5 +1,3 @@
 # SSO Integration
 
-Most applications deployed with UDS are automatically integrated with Keycloak. However, two applications do not support install-time 
-SSO configuration and so must be configured manually. Those are the Atlassian apps, Jira and Confluence. Please reference the 
-Atlassian documentation for guidance in configuring SSO. Their clients exist in keycloak, the SAML details just need added to the apps.
+Most applications deployed with UDS are automatically integrated with Keycloak. However, two applications do not support install-time SSO configuration and so must be configured manually. Those are the Atlassian apps, Jira and Confluence. Please reference the Atlassian documentation for guidance in configuring SSO. Their clients are created in Keycloak, the SAML details just need added to the apps.

--- a/docs/sso-integration.md
+++ b/docs/sso-integration.md
@@ -1,0 +1,5 @@
+# SSO Integration
+
+Most applications deployed with UDS are automatically integrated with Keycloak. However, two applications do not support install-time 
+SSO configuration and so must be configured manually. Those are the Atlassian apps, Jira and Confluence. Please reference the 
+Atlassian documentation for guidance in configuring SSO.

--- a/docs/sso-integration.md
+++ b/docs/sso-integration.md
@@ -2,4 +2,4 @@
 
 Most applications deployed with UDS are automatically integrated with Keycloak. However, two applications do not support install-time 
 SSO configuration and so must be configured manually. Those are the Atlassian apps, Jira and Confluence. Please reference the 
-Atlassian documentation for guidance in configuring SSO.
+Atlassian documentation for guidance in configuring SSO. Their clients exist in keycloak, the SAML details just need added to the apps.


### PR DESCRIPTION
Re: issues #48 and #49. Added note that SSO integration is manual for Jira and Confluence. This completes our work on the big SSO integration ticket.