### PR TITLE
ci: release-please update from deprecated to latest

### DIFF
--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -19,9 +19,7 @@ jobs:
     steps:
       - name: Create Release Tag
         id: tag
-        uses: google-github-actions/release-please-action@a37ac6e4f6449ce8b3f7607e4d97d0146028dc0b # v4
-        with:
-          command: manifest # use configs in release-please-config.json
+        uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
       - id: release-flag
         run: echo "release_created=${{ steps.tag.outputs.release_created || false }}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Updating release-please from the [deprecated version](https://github.com/google-github-actions/release-please-action) to the [new version](https://github.com/googleapis/release-please-action/releases/tag/v4.1.3) while removing a flag that is [no longer needed](https://github.com/googleapis/release-please-action?tab=readme-ov-file#upgrading-from-v3-to-v4).