### PR TITLE
feat: improve reliability by adding periodic pepr restart

### DIFF
--- a/packages/additional-manifests/jobs/pepr-restart-job.yaml
+++ b/packages/additional-manifests/jobs/pepr-restart-job.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: watch-recycle-sa
+  namespace: pepr-system
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: pepr-system
+  name: watch-recycle-role
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "pods"]
+    verbs: ["get", "patch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: watch-recycle-binding
+  namespace: pepr-system
+subjects:
+  - kind: ServiceAccount
+    name: watch-recycle-sa
+roleRef:
+  kind: Role
+  name: watch-recycle-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: pod-deleter-job
+  namespace: pepr-system
+spec:
+  schedule: "*/15 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: watch-recycle-sa
+          restartPolicy: OnFailure
+          containers:
+            - name: kubectl-container
+              image: registry1.dso.mil/ironbank/opensource/kubernetes/kubectl:v1.29.4
+              args:
+                - rollout
+                - restart
+                - deployment/pepr-uds-core-watcher
+                - -n
+                - pepr-system
+            - name: kubectl-container2
+              image: registry1.dso.mil/ironbank/opensource/kubernetes/kubectl:v1.29.4
+              args:
+                - rollout
+                - restart
+                - deployment/pepr-uds-core
+                - -n
+                - pepr-system

--- a/packages/additional-manifests/zarf.yaml
+++ b/packages/additional-manifests/zarf.yaml
@@ -28,3 +28,11 @@ components:
           - pepr-policy-exemptions/metallb-exemptions.yaml
           - pepr-policy-exemptions/gitlab-exemptions.yaml
           - pepr-policy-exemptions/eks-mgmt-exemptions.yaml
+  - name: jobs
+    required: true
+    manifests:
+      - name: jobs-manifests
+        files:
+          - jobs/pepr-restart-job.yaml
+    images:
+      - registry1.dso.mil/ironbank/opensource/kubernetes/kubectl:v1.29.4


### PR DESCRIPTION
in order to avoid issues where pepr can get stuck processing resources, the current workaround is to perform restarts to restore functionality.  this change implements a scheduled job that periodically (every 15 mins) perform a rolling restart of pepr.