### PR TITLE
ci: fix missing input and permissions

### DIFF
--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -29,6 +29,9 @@ jobs:
   # Publish the uds bundle
   publish-uds-bundle-rke2:
     needs: tag-new-version
+    permissions: write-all
     if: ${{ needs.tag-new-version.outputs.release_created == 'true'}}
     uses: ./.github/workflows/publish-bundle-rke2.yaml
+    with:
+      tag-name: ${{ needs.tag-new-version.outputs.release_tag }}
     secrets: inherit


### PR DESCRIPTION
update to the CI workflow to pass in the required input for tag and fix the permissions needed to update the release with the SBOM asset

permissions error seen [here](https://github.com/defenseunicorns/uds-bundle-software-factory-nutanix/actions/runs/11561048712):
```
Invalid workflow file: .github/workflows/tag-and-release.yaml#L33](https://github.com/defenseunicorns/uds-bundle-software-factory-nutanix/actions/runs/11561048712/workflow)
The workflow is not valid. .github/workflows/tag-and-release.yaml (Line: 33, Col: 11): Input tag-name is required, but not provided while calling. .github/workflows/tag-and-release.yaml (Line: 30, Col: 3): Error calling workflow 'defenseunicorns/uds-bundle-software-factory-nutanix/.github/workflows/publish-bundle-rke2.yaml@c4456904aad518af7001b3466ba745e018a03f60'. The workflow is requesting 'contents: write', but is only allowed 'contents: read'
```