### PR TITLE
ci: update renovate per config migration & remove rate limits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
     "github>defenseunicorns/uds-common//config/renovate.json5",
     ":semanticPrefixFixDepsChoreOthers",
     "config:base",
+    ":disableRateLimiting",
     "replacements:all",
     "workarounds:all"
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -4,13 +4,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>defenseunicorns/uds-common//config/renovate.json5",
-    ":semanticPrefixFixDepsChoreOthers",
-    "config:base",
-    ":disableRateLimiting",
-    "replacements:all",
-    "workarounds:all"
+    "config:recommended",
+    ":disableRateLimiting"
   ],
-  "pre-commit": {
-    "enabled": true
-  }
+  "pre-commit": {"enabled": true}
 }


### PR DESCRIPTION
- tweaking the renovate config per the output of the renovate [config validation](https://docs.renovatebot.com/config-validation/) output
```console
npx --yes --package renovate -- renovate-config-validator
```

- updating the config to remove various rate limiting per https://docs.renovatebot.com/presets-default/#disableratelimiting
 
- also of note the move to `config:recommended` per https://docs.renovatebot.com/presets-config/#configrecommended and the associated de-duplication of some configs
