### PR TITLE
chore: remove inspect and sbom publishing from publish workflow

### DIFF
--- a/.github/workflows/publish-bundle-rke2.yaml
+++ b/.github/workflows/publish-bundle-rke2.yaml
@@ -59,16 +59,7 @@ jobs:
       - name: Build and publish rke2 bundle
         run: |
           uds run create-bundle-rke2 --set EXTRA_ARGS="--skip-sbom=false"
-          uds inspect --sbom build/uds-bundle-software-factory-nutanix-rke2*.tar.zst
           uds publish build/uds-bundle-software-factory-nutanix-rke2-amd64-*.tar.zst oci://ghcr.io/defenseunicorns/uds-bundle --no-progress
-
-      - name: Upload SBOM to Release
-        id: upload-sbom-to-release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          TAG_NAME="v${{ inputs.tag-name }}"
-          gh release upload "${TAG_NAME}" "$(find . -maxdepth 1 -type f -name "*-sboms.tar" -print0 | xargs -0 echo)"
 
       - name: Cleanup
         run: |


### PR DESCRIPTION
There is a bug in the uds inspect command causing it to fail when there are duplicate packages in a bundle. For now we need to remove the inspect and sbom publishing from our release workflow until uds-cli resolves this issue